### PR TITLE
投稿にタグ機能を実装

### DIFF
--- a/app/controllers/anomalys_controller.rb
+++ b/app/controllers/anomalys_controller.rb
@@ -2,6 +2,7 @@ class AnomalysController < ApplicationController
   def index
     @q = Anomaly.ransack(params[:q])
     @anomalys = @q.result
+    @tag_list=Tag.all
   end
 
   def new
@@ -10,7 +11,10 @@ class AnomalysController < ApplicationController
   
   def create
     @anomaly = Anomaly.new(anomaly_params)
+
+    tag_list = params[:anomaly][:tag_name].split(',')
     if @anomaly.save
+      @anomaly.save_tag(tag_list)
       flash[:notice] = "新規登録をしました"
       redirect_to :anomalys
     else
@@ -20,10 +24,12 @@ class AnomalysController < ApplicationController
 
   def show
     @anomaly = Anomaly.find(params[:id])
+    @anomaly_tags = @anomaly.tags
   end
 
   def edit
     @anomaly = Anomaly.find(params[:id])
+    @tag_list=@anomaly.tags.pluck(:tag_name).join(',')
   end
 
   def update

--- a/app/models/anomaly.rb
+++ b/app/models/anomaly.rb
@@ -1,7 +1,30 @@
 class Anomaly < ApplicationRecord
   has_rich_text :content
 
+  has_many :anomaly_tags,dependent: :destroy
+  has_many :tags,through: :anomaly_tags
+
   def self.ransackable_attributes(auth_object = nil)
     ["title"]
+  end
+
+  def save_tag(sent_tags)
+     #タグが存在していれば、タグの名前を配列として全て取得
+     current_tags = self.tags.pluck(:tag_name) unless self.tags.nil?
+     # 現在取得したタグから送られてきたタグを除いてoldtagとする
+     old_tags = current_tags - sent_tags
+     # 送信されてきたタグから現在存在するタグを除いたタグをnewとする
+     new_tags = sent_tags - current_tags
+
+        # 古いタグを消す
+     old_tags.each do |old|
+       self.tags.delete Tag.find_by(tag_name: old)
+     end
+
+        # 新しいタグを保存
+     new_tags.each do |new|
+       new_post_tag = Tag.find_or_create_by(tag_name: new)
+       self.tags << new_post_tag
+    end
   end
 end

--- a/app/models/anomaly_tag.rb
+++ b/app/models/anomaly_tag.rb
@@ -1,0 +1,7 @@
+class AnomalyTag < ApplicationRecord
+  belongs_to :anomaly
+  belongs_to :tag
+  
+  validates :anomaly_id, presence: true
+  validates :tag_id, presence: true
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :anomaly_tags,dependent: :destroy, foreign_key: 'tag_id'
+  has_many :anomalys,through: :anomaly_tags
+  
+  validates :tag_name, uniqueness: true, presence: true
+end

--- a/app/views/anomalys/_form.html.erb
+++ b/app/views/anomalys/_form.html.erb
@@ -1,8 +1,13 @@
 <div class="form-group">
-  <%= form_with model: @anomaly do |f| %>
+  <%= form_with model: @anomaly, url: anomalys_path do |f| %>
     <div>
       <%= f.label :title %>
       <%= f.text_field :title, required: true, placeholder: "タイトル" %>
+    </div>
+
+    <div>
+      <%= f.label :tag_name, "タグ (,で区切ると複数タグ登録できます)" %>
+      <%= f.text_field :tag_name, class:"form-control"%>
     </div>
   
     <div class='field'>

--- a/app/views/anomalys/index.html.erb
+++ b/app/views/anomalys/index.html.erb
@@ -13,6 +13,17 @@
   <%= f.submit '検索' %>
 <% end %>
 
+<!--タグリスト-->
+<% @tag_list.each do |list|%>
+  <%=list.tag_name %>
+  <%="(#{list.anomalys.count})" %>
+<% end %>
+
+投稿一覧画面で投稿に紐づくタグを表示
+<% @anomalys.each do |anomaly| %>
+  <i class="fas fa-tag"><%= anomaly.tags.map(&:tag_name).join(', ') %></i>
+<% end %>
+
   <% @anomalys.each do |anomaly| %>  
     <div class="col-xs-12 anomalys">
       <div class="row">

--- a/app/views/anomalys/show.html.erb
+++ b/app/views/anomalys/show.html.erb
@@ -1,5 +1,8 @@
 <div class="anomaly-show text-break">
   <h2 class="my-3"><%= @anomaly.title %></h2>
+  <% @anomaly_tags.each do |tag| %>
+    <%=tag.tag_name%><%="(#{tag.anomalys.count})" %>
+  <% end %>
   <%= @anomaly.content %>
 </div>
 

--- a/db/migrate/20230408031156_create_tags.rb
+++ b/db/migrate/20230408031156_create_tags.rb
@@ -1,0 +1,9 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string :tag_name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230408031448_create_anomaly_tags.rb
+++ b/db/migrate/20230408031448_create_anomaly_tags.rb
@@ -1,0 +1,10 @@
+class CreateAnomalyTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :anomaly_tags do |t|
+      t.references :anomaly, null: false, foreign_key: true
+      t.references :tag, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_04_025859) do
+ActiveRecord::Schema.define(version: 2023_04_08_031448) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -57,6 +57,23 @@ ActiveRecord::Schema.define(version: 2023_04_04_025859) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "anomaly_tags", force: :cascade do |t|
+    t.integer "anomaly_id", null: false
+    t.integer "tag_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["anomaly_id"], name: "index_anomaly_tags_on_anomaly_id"
+    t.index ["tag_id"], name: "index_anomaly_tags_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "tag_name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "anomaly_tags", "anomalies"
+  add_foreign_key "anomaly_tags", "tags"
 end

--- a/test/fixtures/anomaly_tags.yml
+++ b/test/fixtures/anomaly_tags.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  anomaly: one
+  tag: one
+
+two:
+  anomaly: two
+  tag: two

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  tag_name: MyString
+
+two:
+  tag_name: MyString

--- a/test/models/anomaly_tag_test.rb
+++ b/test/models/anomaly_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class AnomalyTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #11

**目的**
・投稿ごとにタグを付けれるよう実装する。
・投稿に対して、複数タグを付けれるように実装する。

**実装内容**
・tagモデルとanomaly_tagモデルを作成。
・anomalyモデル、tagモデル、anomaly_tagモデルにそれぞれアソシエーションを定義しモデルの関連付けをしました。
・anomalyモデルにsave_tagを定義し、新しいタグを保存できるようにしました。
・anomalyコントローラーにタグ機能を追加し、viewファイルにタグが表示されるように修正しました。
