### PR TITLE
コメントの削除機能の実装

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,15 +1,24 @@
 class CommentsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def create
     @comment = current_user.comments.new(comment_params)
     if @comment.save
-      redirect_back(fallback_location: root_path)  #コメント送信後は、一つ前のページへリダイレクトさせる。
+      redirect_back(fallback_location: root_path)
     else
-      redirect_back(fallback_location: root_path)  #同上
+      redirect_back(fallback_location: root_path)
     end
+  end
+
+  def destroy
+    @comment = Comment.find(params[:id])
+      @comment.destroy
+      flash[:success] = "コメント削除完了"
+      redirect_to anomaly_path(@comment.anomaly_id)
   end
   
   private
   def comment_params
-    params.require(:comment).permit(:comment_content, :anomaly_id)  #formにてpost_idパラメータを送信して、コメントへpost_idを格納するようにする必要がある。
+    params.require(:comment).permit(:comment_content, :anomaly_id)
   end
 end

--- a/app/views/anomalys/show.html.erb
+++ b/app/views/anomalys/show.html.erb
@@ -8,7 +8,7 @@
     <%= @anomaly.content %>
   </div>
   
-  <%= render @comments %>
+  <%= render partial: 'comments/comment' %>
 
   <%= link_to "戻る",:back, class: "btn other-btn btn-block"  %>
   

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -10,6 +10,15 @@
       <div class="">
         <%= comment.comment_content %>
       </div>
+      <% if comment.user_id == @current_user.id %>
+        <div class="row">
+          <div class="offset-md-11">
+            <%= link_to comment_path(comment), method: :delete do %>
+              <i class="bi bi-x"></i>削除
+            <% end %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
   

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
     resources :comments, only: [:create]
   end
   get "search_tag"=>"anomalys#search_tag"
+  resources :comments, only: :destroy
 end


### PR DESCRIPTION
close #42 

**実装内容**
・コメントコントローラーにdestroyを定義し、コメント削除できるようにしました。
・コメント欄に削除のアイコンを表示しました。

**バグ修正**
・ユーザーを変更したときCan't verify CSRF token authenticityというエラーが発生し、正常に登録することできなかったので、skip_before_action :verify_authenticity_tokenをcommentコントローラーに加え、CSRF対策によるトークンの検証を無効化することで対応しました。