### PR TITLE
投稿画面の投稿リストに名前と日付を表示

### DIFF
--- a/app/assets/stylesheets/anomalys.scss
+++ b/app/assets/stylesheets/anomalys.scss
@@ -32,6 +32,14 @@
   margin-bottom: 20px;
 }
 
+.anomaly-header {
+  margin-bottom: 20px;
+}
+
+.anomaly-content {
+  padding: 10px 0px 10px 0px;
+}
+
 /* ページネーション */
 .pagination {
   display: flex;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,8 +65,8 @@ body {
   background-color: $anomaly-list-color;
   border-top: 1px solid $anomaly-list-border-color;
   border-bottom: 1px solid $anomaly-list-border-color;
-  margin: 0 200px 0px 200px ;
-  padding: 60px 16px 0px 60px;
+  margin: 0 250px 0px 250px;
+  padding: 30px 16px 0px 30px;
   width: 100%;
   box-shadow: 2px 2px 7px 6px RGB(0 0 0 / 4%);
   background-color: #ffffff;

--- a/app/controllers/anomalys_controller.rb
+++ b/app/controllers/anomalys_controller.rb
@@ -12,8 +12,7 @@ class AnomalysController < ApplicationController
   end
   
   def create
-    @anomaly = Anomaly.new(anomaly_params)
-
+    @anomaly = current_user.anomalys.new(anomaly_params)
     tag_list = params[:anomaly][:tag_name].split(',')
     if @anomaly.save
       @anomaly.save_tag(tag_list)

--- a/app/views/anomalys/index.html.erb
+++ b/app/views/anomalys/index.html.erb
@@ -33,6 +33,10 @@
     <div class="col-xs-12 anomalys">
       <div class="row">
         <div class="anomaly text-break">
+          <div class="anomaly-header">
+            <%= link_to "#{anomaly.user.name}", users_path(anomaly.user.id), class:"erb-link" %>
+            <%= "が#{anomaly.created_at.strftime('%Y/%m/%d %H:%M')}に投稿" %>
+          </div>
           <table>
             <thead>
               <tr align="center">
@@ -44,7 +48,9 @@
             </thead>  
               <tbody>
                 <tr>
-                  <td><%= anomaly.title %></td>
+                  <td>
+                    <%= anomaly.title %>
+                  </td>
                   <td>
                     <%= link_to "確認", anomaly %>
                   </td>


### PR DESCRIPTION
close #57 

**実装内容**
・anomalysコントローラーで異常リストを保存する際ユーザーidも一緒に保存できるようにしました。
・異常リストにユーザー名と日付を追加しました。
・cssで文字の位置と異常リストの大きさの変更