### PR TITLE
HerokuにデプロイしたときFailed to install gems via Bundlerエラーが発生したため

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.4.6)
     pry (0.14.2)
@@ -225,6 +227,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.2-arm64-darwin)
+    sqlite3 (1.6.2-x86_64-linux)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -259,6 +262,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)


### PR DESCRIPTION
**エラー対処**
・Heroku にデプロイしたときFailed to install gems via Bundlerエラーが発生したため、bundle lock --add-platform x86_64-linuxを実行しました。
・原因は、herokuのbundlerとローカルでのbundlerのバージョンに相違があるためのようです。