### PR TITLE
circleciでマニフェストが不明のエラーが出たためpostgresの設定を変更

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     parallelism: 3
     docker:
       - image: cimg/ruby:3.1.3-browsers
-      - image: circleci/postgres:14.7-alpine
+      - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: user_name
           POSTGRES_DB: your_db_name
@@ -36,7 +36,7 @@ jobs:
     parallelism: 3
     docker:
       - image: cimg/ruby:3.1.3-browsers
-      - image: circleci/postgres:14.7-alpine
+      - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: user_name
           POSTGRES_DB: your_db_name


### PR DESCRIPTION
・CircleCI上でcircleci/postgres:14.7-alpine のマニフェストが見つかりません。とエラーが出たため、postgres:9.5に記述を変更