### PR TITLE
rubocopでUniqueValidationWithoutIndexエラーが出たためTagsテーブルにユニーク制約を追加

### DIFF
--- a/db/migrate/20230507023217_add_index_tags_tag_name.rb
+++ b/db/migrate/20230507023217_add_index_tags_tag_name.rb
@@ -1,0 +1,5 @@
+class AddIndexTagsTagName < ActiveRecord::Migration[6.1]
+  def change
+    add_index :tags, :tag_name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_17_072753) do
+ActiveRecord::Schema.define(version: 2023_05_07_023217) do
 
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.string "name", null: false
@@ -80,6 +80,7 @@ ActiveRecord::Schema.define(version: 2023_04_17_072753) do
     t.string "tag_name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["tag_name"], name: "index_tags_on_tag_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
**エラー対処**
・Tagsテーブルのtag_nameに一意性制約がなかった為、UniqueValidationWithoutIndexエラーが出ました。
・indexを追加する為、新たにマイグレーションファイルを作成しtag_nameにunique: trueを付与しました。