### PR TITLE
RubocopでHasManyOrHasOneDependentエラーが出た為userモデルにdependentオプションを追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,8 +5,8 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   validates :name, presence: true
 
-  has_many :anomalys
-  has_many :comments
+  has_many :anomalys, dependent: :nullify
+  has_many :comments, dependent: :nullify
 
   def self.guest
     find_or_create_by!(email: 'guest@example.com') do |user|


### PR DESCRIPTION
**エラー対処**
・Rubocopでdependentオプションを付けるよう求められたので、userモデルの関連付けにdependent: :nullifyを追加し、userが削除された場合、userのみを削除するようにしました。