### PR TITLE
Model Specの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'spring-commands-rspec'
   gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (3.2.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.1.0)
       activesupport (>= 5.0)
@@ -344,6 +346,7 @@ DEPENDENCIES
   capybara (>= 3.26)
   devise
   factory_bot_rails
+  faker
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   kaminari

--- a/spec/factories/anomalies.rb
+++ b/spec/factories/anomalies.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :anomaly do
+    title { Faker::Book.title }
+    content { Faker::Lorem.sentence }
+    user
+  end
+end

--- a/spec/factories/anomaly_tags.rb
+++ b/spec/factories/anomaly_tags.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :anomaly_tag do
+    anomaly
+    tag
+  end
+end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :comment do
+    user
+    anomaly
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    sequence(:tag_name) {|n| "tag#{n}" }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :tag do
-    sequence(:tag_name) {|n| "tag#{n}" }
+    sequence(:tag_name) { |n| "tag#{n}" }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Lorem.characters(number: Random.new.rand(1..20)) }
+    sequence(:email) { |n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
+  end
+end

--- a/spec/models/anomaly_spec.rb
+++ b/spec/models/anomaly_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe Anomaly, type: :model do
+  describe "正常なとき" do
+    context "タイトルと本文が存在するとき" do
+      let(:anomaly) { build(:anomaly) }
+      it "投稿が作成される" do
+        expect(anomaly).to be_valid
+      end
+    end
+  end
+
+  describe "異常なとき" do
+    context "投稿のtitleが無いとき" do
+      let(:anomaly) { build(:anomaly, title: nil) }
+      it "投稿の作成に失敗する" do
+        expect(anomaly).to be_invalid
+      end
+    end
+
+    context "投稿のcontentが無いとき" do
+      let(:anomaly) { build(:anomaly, content: nil) }
+      it "投稿の作成に失敗する" do
+        expect(anomaly).to be_invalid
+      end
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Userモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Anomaly.reflect_on_association(:user).macro).to eq :belongs_to
+      end
+    end
+
+    context 'AnomalyTagモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Anomaly.reflect_on_association(:anomaly_tags).macro).to eq :has_many
+      end
+    end
+
+    context 'Tagモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Anomaly.reflect_on_association(:tags).macro).to eq :has_many
+      end
+    end
+
+    context 'Commentモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Anomaly.reflect_on_association(:comments).macro).to eq :has_many
+      end
+    end
+  end
+end

--- a/spec/models/anomaly_spec.rb
+++ b/spec/models/anomaly_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Anomaly, type: :model do
       let(:anomaly) { build(:anomaly, title: nil) }
       it "投稿の作成に失敗する" do
         expect(anomaly).to be_invalid
+        expect(anomaly.errors.full_messages).to include('タイトルを入力してください')
       end
     end
 
@@ -22,6 +23,7 @@ RSpec.describe Anomaly, type: :model do
       let(:anomaly) { build(:anomaly, content: nil) }
       it "投稿の作成に失敗する" do
         expect(anomaly).to be_invalid
+        expect(anomaly.errors.full_messages).to include('本文を入力してください')
       end
     end
   end

--- a/spec/models/anomaly_tag_spec.rb
+++ b/spec/models/anomaly_tag_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe AnomalyTag, type: :model do
+  describe "正常なとき" do
+    context "anomaly_id と tag_idが存在すること" do
+      let(:anomaly_tag) { create(:anomaly_tag) }
+      it "有効である" do
+        expect(anomaly_tag).to be_valid
+      end
+    end
+  end
+
+  describe "異常なとき" do
+    context "anomaly_idが存在しないこと" do
+      let(:anomaly_tag) { build(:anomaly_tag, anomaly_id: nil) }
+      it "エラーになる" do
+        expect(anomaly_tag).to be_invalid
+      end
+    end
+
+    context "tag_idが存在しないこと" do
+      let(:anomaly_tag) { build(:anomaly_tag, tag_id: nil) }
+      it "エラーになる" do
+        expect(anomaly_tag).to be_invalid
+      end
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Anomalyモデルとの関係' do
+      it 'N:1となっている' do
+        expect(AnomalyTag.reflect_on_association(:anomaly).macro).to eq :belongs_to
+      end
+    end
+
+    context 'Tagモデルとの関係' do
+      it 'N:1となっている' do
+        expect(AnomalyTag.reflect_on_association(:tag).macro).to eq :belongs_to
+      end
+    end
+  end
+end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Comment, type: :model do
+  describe "異常なとき" do
+    context '有効な値の場合' do
+      let(:comment) { create(:comment) }
+      it 'commentが有効であること' do
+        expect(comment).to be_valid
+      end
+    end
+  end
+
+  describe "異常なとき" do
+    context "anomaly_idが存在しないこと" do
+      let(:comment) { build(:comment, anomaly_id: nil) }
+      it "エラーになる" do
+        expect(comment).to be_invalid
+      end
+    end
+
+    context "user_idが存在しないこと" do
+      let(:comment) { build(:comment, user_id: nil) }
+      it "エラーになる" do
+        expect(comment).to be_invalid
+      end
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Anomalyモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Comment.reflect_on_association(:anomaly).macro).to eq :belongs_to
+      end
+    end
+
+    context 'Tagモデルとの関係' do
+      it 'N:1となっている' do
+        expect(Comment.reflect_on_association(:user).macro).to eq :belongs_to
+      end
+    end
+  end
+end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Tag, type: :model do
+  context "タグが入力されている時" do
+    let(:tag) { build(:tag) }
+    it "タグが生成できる" do
+      expect(tag).to be_valid
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'Anomalyモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Tag.reflect_on_association(:anomalys).macro).to eq :has_many
+      end
+    end
+
+    context 'AnomalyTagモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(Tag.reflect_on_association(:anomaly_tags).macro).to eq :has_many
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context "必要な情報が揃っているとき" do
+    let(:user) { build(:user) }
+    it "ユーザー登録できる" do
+      expect(user).to be_valid
+    end
+  end
+
+  context "ユーザーネームがないとき" do
+    let(:user) { build(:user, name: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+    end
+  end
+
+  context "メールアドレスがないとき" do
+    let(:user) { build(:user, email: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+    end
+  end
+
+  context "passwordがないとき" do
+    let(:user) { build(:user, password: nil) }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+    end
+  end
+
+  context "password確認が違うとき" do
+    let(:user) { build(:user, password_confirmation: "hogehoge") }
+    it "ユーザーの作成に失敗する" do
+      expect(user).to be_invalid
+    end
+  end
+
+  describe 'アソシエーションのテスト' do
+    context 'AnomalyTagモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(User.reflect_on_association(:anomalys).macro).to eq :has_many
+      end
+    end
+
+    context 'Tagモデルとの関係' do
+      it '1:Nとなっている' do
+        expect(User.reflect_on_association(:comments).macro).to eq :has_many
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #88 

**実装内容**
・bin/rails g rspec:modelを実行し、spec/factories, spec/modelsを作成しました。
・各モデルのmodel specを実装しました。
・FactoryBotでfakerを使いダミーデータを作成し、関連付けの記述を追加しました。