### PR TITLE
投稿詳細ページのデザインの修正

### DIFF
--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,5 +1,4 @@
 $main-color: #13165e;
-$accent-color: #7ec2c2;
 $other-color: #c6cff1;
 $sub-color: #ff6a00;
 
@@ -8,6 +7,12 @@ $anomaly-list-color: #f8f8f8;
 $anomaly-list-border-color: #cac8c8;
 
 @mixin btn_color($color: $sub-color) {
+  background-color: $color;
+  border-color: $color;
+  color: #fff;
+}
+
+@mixin btn_other($color: $other-color) {
   background-color: $color;
   border-color: $color;
   color: #fff;

--- a/app/assets/stylesheets/anomalys.scss
+++ b/app/assets/stylesheets/anomalys.scss
@@ -4,8 +4,9 @@
 @import "variables.scss";
 
 .anomaly-show {
-  background-color: $anomaly-list-color;
+  background-color: white;
   padding: 1rem;
+  box-shadow: 2px 2px 7px 6px RGB(0 0 0 / 4%);
 }
 
 .search-form {

--- a/app/assets/stylesheets/anomalys.scss
+++ b/app/assets/stylesheets/anomalys.scss
@@ -49,6 +49,10 @@
   margin-left : 15px;
 }
 
+.anomaly-tags {
+  margin-bottom: 110px;
+}
+
 /* ページネーション */
 .pagination {
   display: flex;
@@ -62,7 +66,7 @@
       border-color: $main-color;
       &:hover, &:focus {
         background-color: $main-color;
-        border-color: $accent-color;
+        border-color: $other-color;
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -90,9 +90,6 @@ footer {
     justify-content: space-between;
   }
 }
-.fa-tags {
-  color: $accent-color;
-}
 
 /* _form */
 .form {
@@ -119,7 +116,7 @@ footer {
   @include btn_color;
 }
 .other-btn {
-  @include btn_color($other-color);
+  @include btn_other($other-color);
 }
 .btn-search {
   background-color: $other-color;

--- a/app/views/anomalys/edit.html.erb
+++ b/app/views/anomalys/edit.html.erb
@@ -18,11 +18,8 @@
       <%= f.rich_text_area :content %>
     </div>
   
-    <div class="actions new_form_frame">
-      <%= f.submit "投稿", class:"post-btn mt-5" %>
+    <div class="actions new_form_frame text-center">
+      <%= f.submit "投稿", class:"post-btn mt-5 w-50" %>
     </div>
   <% end %>
-  <div class='field new_form_frame'>
-    <%= link_to "取り消し",:back, class: "btn btn-block cancel-btn mt-5 ", data: { confirm: "作成データを破棄しますか？" } %>
-  </div> 
 </div>

--- a/app/views/anomalys/search_tag.html.erb
+++ b/app/views/anomalys/search_tag.html.erb
@@ -1,21 +1,6 @@
-<h3 class="text-center"><%= "#{@tag.tag_name} を含む異常一覧" %></h3>
 <div class="container-fluid">
-  <% @tag_list.each do |list|%>
-    <div class="anomaly-tags">
-      <i class="bi bi-tag"></i>
-      <%=link_to list.tag_name, search_tag_path(tag_id: list.id) %>
-      <%="(#{list.anomalys.count})" %>
-    </div>
-  <% end %>
-  
-  <div class="anomaly-tags mt-2">
-    <% @anomalys.each do |anomaly| %>
-      <i class="fas fa-tag"><%= anomaly.tags.map(&:tag_name).join(', ') %></i>
-    <% end %>
-  </div>
-  
-  <%= render 'anomaly_list' %>
-    
+<div class="anomaly-tags">
+  <h3 class=" text-center"><%= "#{@tag.tag_name} を含む異常一覧" %></h3>
 </div>
-
-<%= link_to "戻る",:back, class: "btn other-btn btn-block"  %>
+  <%= render 'anomaly_list' %>
+</div>

--- a/app/views/anomalys/show.html.erb
+++ b/app/views/anomalys/show.html.erb
@@ -1,7 +1,19 @@
 <div class="container">
   <div class="anomaly-show text-break">
+  <div class="row">
+    <% if @anomaly.user == current_user %>
+      <div class=" offset-md-10">
+        <%= link_to edit_anomaly_path(@anomaly), class:"mgr-10" do %>
+          <i class="bi bi-pencil"></i>編集
+        <% end %>
+        <%= link_to anomaly_path(@anomaly), method: :delete, data: { confirm: "削除しますか？" }, class:"mgr-10" do %>
+          <i class="bi bi-x"></i>削除
+        <% end %>
+      </div>
+    <% end %>
+
     <h2 class="my-3"><%= @anomaly.title %></h2>
-    
+  </div>
     <% @anomaly_tags.each do |tag| %>
       <i class="bi bi-tag"></i>
       <%= link_to tag.tag_name,search_tag_path(tag_id: tag.id)%><%="(#{tag.anomalys.count})" %>
@@ -14,11 +26,4 @@
   <% if user_signed_in? %>
     <%= render "comments/form" %>
   <% end %> 
-
-  <% if @anomaly.user == current_user %>
-    <div class="author float-right">
-      <%= link_to '編集', edit_anomaly_path(@anomaly), class:"btn" %>
-      <%= link_to '削除', anomaly_path(@anomaly), method: :delete, data: { confirm: "削除しますか？" }, class:"btn" %>
-    </div>
-  <% end %>
 </div>

--- a/app/views/anomalys/show.html.erb
+++ b/app/views/anomalys/show.html.erb
@@ -15,8 +15,6 @@
     <%= render "comments/form" %>
   <% end %> 
 
-  <%= link_to "戻る",:back, class: "btn other-btn btn-block"  %>
-  
   <% if @anomaly.user == current_user %>
     <div class="author float-right">
       <%= link_to '編集', edit_anomaly_path(@anomaly), class:"btn" %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -6,7 +6,7 @@
         <%= f.text_area :comment_content, class: "form-control-h form-control"%>
       </div>  
       <%= f.hidden_field :anomaly_id, value: @anomaly.id %>
-      <%= f.submit '投稿', class: "post-comment offset-md-5" %>
+      <%= f.submit '投稿', class: "post-comment offset-md-11" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
close #101 

**実装内容**
・コメントの投稿ボタンの位置の変更
・編集ページの投稿ボタンのデザインを変更
・投稿詳細ページのcontentのフォームのデザインの変更
・投稿詳細ページの戻るボタンの削除
・編集と削除のボタンの位置と色を変更
・編集と削除のボタンにアイコンを追加
・タグで検索した異常一覧の不要な部分の削除