### PR TITLE
AWSに自動デプロイする為Capistranoの導入

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,0 +1,12 @@
+# Load DSL and set up stages
+require "capistrano/setup"
+# Include default deployment tasks
+require "capistrano/deploy"
+require "capistrano/rbenv"
+require "capistrano/bundler"
+require "capistrano/rails/assets"
+require "capistrano/rails/migrations"
+require "capistrano3/unicorn"
+require "capistrano/scm/git"
+install_plugin Capistrano::SCM::Git
+Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,12 @@ group :development do
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
+  # Capistranoの導入
+  gem 'capistrano'
+  gem 'capistrano-rbenv'
+  gem 'capistrano-bundler'
+  gem 'capistrano-rails'
+  gem 'capistrano3-unicorn'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.2)
       public_suffix (>= 2.0.2, < 6.0)
+    airbrussh (1.4.1)
+      sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.759.0)
@@ -85,6 +87,21 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
+    capistrano (3.17.3)
+      airbrussh (>= 1.0.0)
+      i18n
+      rake (>= 10.0.0)
+      sshkit (>= 1.9.0)
+    capistrano-bundler (2.1.0)
+      capistrano (~> 3.1)
+    capistrano-rails (1.6.2)
+      capistrano (~> 3.1)
+      capistrano-bundler (>= 1.1, < 3)
+    capistrano-rbenv (2.2.0)
+      capistrano (~> 3.1)
+      sshkit (~> 1.3)
+    capistrano3-unicorn (0.2.1)
+      capistrano (~> 3.1, >= 3.1.0)
     capybara (3.39.0)
       addressable
       matrix
@@ -164,8 +181,11 @@ GEM
       net-protocol
     net-protocol (0.2.1)
       timeout
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
     net-smtp (0.3.3)
       net-protocol
+    net-ssh (7.1.0)
     nio4r (2.5.9)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
@@ -303,6 +323,9 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.6.2-arm64-darwin)
     sqlite3 (1.6.2-x86_64-linux)
+    sshkit (1.21.4)
+      net-scp (>= 1.1.2)
+      net-ssh (>= 2.8.0)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -348,6 +371,11 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap (>= 1.4.4)
   byebug
+  capistrano
+  capistrano-bundler
+  capistrano-rails
+  capistrano-rbenv
+  capistrano3-unicorn
   capybara (>= 3.26)
   devise
   factory_bot_rails

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -9,8 +9,8 @@ append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "vendor/bund
 
 # SSH接続設定
 set :ssh_options, {
-  auth_methods: ['publickey'], 
-  keys: ['~/.ssh/anocolle.pem'] 
+  auth_methods: ['publickey'],
+  keys: ['~/.ssh/anocolle.pem']
 }
 
 # 保存しておく世代の設定

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,0 +1,35 @@
+# config valid for current version and patch releases of Capistrano
+lock "3.17.3"
+
+set :application, "anocolle"
+set :repo_url, "git@github.com:uezu-iy/anocolle.git"
+
+# sharedディレクトリに入れるファイルを指定
+append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "vendor/bundle", "public/system", "public/uploads"
+
+# SSH接続設定
+set :ssh_options, {
+  auth_methods: ['publickey'], 
+  keys: ['~/.ssh/anocolle.pem'] 
+}
+
+# 保存しておく世代の設定
+set :keep_releases, 5
+
+# rbenvの設定
+set :rbenv_type, :user
+set :rbenv_ruby, '3.1.3'
+
+# Unicornのプロセスの指定
+set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
+
+# Unicornの設定ファイルの指定
+set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
+
+# Unicornを再起動するための記述
+after 'deploy:publishing', 'deploy:restart'
+namespace :deploy do
+  task :restart do
+    invoke 'unicorn:restart'
+  end
+end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,0 +1,61 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
+# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
+# server "db.example.com", user: "deploy", roles: %w{db}
+server '35.79.33.31', user: 'ec2-user', roles: %w{app db web}
+
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/user_name/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server "example.com",
+#   user: "user_name",
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: "user_name", # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: "please use keys"
+#   }

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,8 +6,7 @@
 # server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
-server '35.79.33.31', user: 'ec2-user', roles: %w{app db web}
-
+server '35.79.33.31', user: 'ec2-user', roles: %w[app db web]
 
 # role-based syntax
 # ==================
@@ -21,8 +20,6 @@ server '35.79.33.31', user: 'ec2-user', roles: %w{app db web}
 # role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
 # role :db,  %w{deploy@example.com}
 
-
-
 # Configuration
 # =============
 # You can set any configuration variable like in config/deploy.rb
@@ -30,8 +27,6 @@ server '35.79.33.31', user: 'ec2-user', roles: %w{app db web}
 # For available Capistrano configuration variables see the documentation page.
 # http://capistranorb.com/documentation/getting-started/configuration/
 # Feel free to add new variables to customise your setup.
-
-
 
 # Custom SSH Options
 # ==================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -7,8 +7,6 @@
 # server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
 # server "db.example.com", user: "deploy", roles: %w{db}
 
-
-
 # role-based syntax
 # ==================
 
@@ -21,8 +19,6 @@
 # role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
 # role :db,  %w{deploy@example.com}
 
-
-
 # Configuration
 # =============
 # You can set any configuration variable like in config/deploy.rb
@@ -30,8 +26,6 @@
 # For available Capistrano configuration variables see the documentation page.
 # http://capistranorb.com/documentation/getting-started/configuration/
 # Feel free to add new variables to customise your setup.
-
-
 
 # Custom SSH Options
 # ==================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -1,0 +1,61 @@
+# server-based syntax
+# ======================
+# Defines a single server with a list of roles and multiple properties.
+# You can define all roles on a single server, or split them:
+
+# server "example.com", user: "deploy", roles: %w{app db web}, my_property: :my_value
+# server "example.com", user: "deploy", roles: %w{app web}, other_property: :other_value
+# server "db.example.com", user: "deploy", roles: %w{db}
+
+
+
+# role-based syntax
+# ==================
+
+# Defines a role with one or multiple servers. The primary server in each
+# group is considered to be the first unless any hosts have the primary
+# property set. Specify the username and a domain or IP for the server.
+# Don't use `:all`, it's a meta role.
+
+# role :app, %w{deploy@example.com}, my_property: :my_value
+# role :web, %w{user1@primary.com user2@additional.com}, other_property: :other_value
+# role :db,  %w{deploy@example.com}
+
+
+
+# Configuration
+# =============
+# You can set any configuration variable like in config/deploy.rb
+# These variables are then only loaded and set in this stage.
+# For available Capistrano configuration variables see the documentation page.
+# http://capistranorb.com/documentation/getting-started/configuration/
+# Feel free to add new variables to customise your setup.
+
+
+
+# Custom SSH Options
+# ==================
+# You may pass any option but keep in mind that net/ssh understands a
+# limited set of options, consult the Net::SSH documentation.
+# http://net-ssh.github.io/net-ssh/classes/Net/SSH.html#method-c-start
+#
+# Global options
+# --------------
+#  set :ssh_options, {
+#    keys: %w(/home/user_name/.ssh/id_rsa),
+#    forward_agent: false,
+#    auth_methods: %w(password)
+#  }
+#
+# The server-based syntax can be used to override options:
+# ------------------------------------
+# server "example.com",
+#   user: "user_name",
+#   roles: %w{web app},
+#   ssh_options: {
+#     user: "user_name", # overrides user setting above
+#     keys: %w(/home/user_name/.ssh/id_rsa),
+#     forward_agent: false,
+#     auth_methods: %w(publickey password)
+#     # password: "please use keys"
+#   }

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,5 +1,5 @@
 # rootパスのディレクトリを指定
-root_path = File.expand_path('../../../', __FILE__)
+root_path = File.expand_path('../..', __dir__)
 
 # アプリケーションサーバの性能を決定する
 worker_processes 2

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,23 +1,23 @@
 # rootパスのディレクトリを指定
-root_path = File.expand_path('..', __dir__)
+root_path = File.expand_path('../../../', __FILE__)
 
 # アプリケーションサーバの性能を決定する
 worker_processes 2
 
 # アプリケーションの設置されているディレクトリを指定
-working_directory root_path
+working_directory "#{root_path}/current"
 
 # プロセスIDの保存先を指定
-pid "#{root_path}/tmp/pids/unicorn.pid"
+pid "#{root_path}/shared/tmp/pids/unicorn.pid"
 
 # ポート番号を指定
-listen "#{root_path}/tmp/sockets/unicorn.sock"
+listen "#{root_path}/shared/tmp/sockets/unicorn.sock"
 
 # エラーのログを記録するファイルを指定
-stderr_path "#{root_path}/log/unicorn.stderr.log"
+stderr_path "#{root_path}/shared/log/unicorn.stderr.log"
 
 # 通常のログを記録するファイルを指定
-stdout_path "#{root_path}/log/unicorn.stdout.log"
+stdout_path "#{root_path}/shared/log/unicorn.stdout.log"
 
 # 応答時間を待つ上限時間を設定
 timeout 30


### PR DESCRIPTION
close #106 

**実装内容**
・Capistranoを導入するためのgemを追加
・bundle exec cap installを実行し必要なファイルを作成
・インストールしたgemの中からCapistranoで読み込むgemを指定するファイルであるCapfileを編集
・deploy.rbを編集し、デプロイ時に行われるタスクを設定
・production.rbを編集し、本番環境のデプロイを設定
・ディレクトリ構成の変更をするためunicorn.rbを編集