### PR TITLE
LoadError: Error loading the 'sqlite3' Active Record adapterの対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,11 +42,12 @@ gem 'aws-sdk-s3', require: false
 #日本語化
 gem 'rails-i18n'
 
+gem 'sqlite3', '~> 1.4'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Use sqlite3 as the database for Active Record
-  gem 'sqlite3', '~> 1.4'
   gem 'rspec-rails'
   gem 'spring-commands-rspec'
   gem 'factory_bot_rails'


### PR DESCRIPTION
**エラー対応**
・LoadError: Error loading the 'sqlite3' Active Record adapter. Missing a gem it depends on? sqlite3 is not part of the bundle. Add it to your Gemfile.と言われたので、すべての環境でsqlite3が使えるようにしました。