### PR TITLE
CircleCiでAWS EC2にデプロイ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           install-yarn: true
           node-version: '16.13'
       - add_ssh_keys:
-          fingerprints:"8a:9b:fc:e3:12:a0:d3:1e:c2:62:98:a6:7b:56:d8:3d"
+          fingerprints: "8a:9b:fc:e3:12:a0:d3:1e:c2:62:98:a6:7b:56:d8:3d"
       - deploy:
           name: Capistrano deploy
           command: bundle exec cap production deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,24 +72,19 @@ jobs:
   deploy:
     docker:
       - image: cimg/ruby:3.1.3-browsers
+        environment:
+          BUNDLER_VERSION: 2.1.4
     steps:
       - checkout
-      - run:
-          name: 'Install Heroku CLI, if necessary'
-          command: |
-            if [[ $(command -v heroku) == "" ]]; then
-              curl https://cli-assets.heroku.com/install.sh | sh
-            else
-              echo "Heroku is already installed. No operation was performed."
-            fi
-      - run:
-          name: Deploy to Heroku_Production
-          command: |
-            git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME_PRD.git main
-      - run:
-          name: db migration
-          command: |
-            heroku run rails db:migrate --app ${HEROKU_APP_NAME_PRD}
+      - ruby/install-deps
+      - node/install:
+          install-yarn: true
+          node-version: '16.13'
+      - add_ssh_keys:
+          fingerprints:"8a:9b:fc:e3:12:a0:d3:1e:c2:62:98:a6:7b:56:d8:3d"
+      - deploy:
+          name: Capistrano deploy
+          command: bundle exec cap production deploy
 workflows:
   version: 2
   build_and_rubocop_and_test:

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,11 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '35.79.33.31', user: 'ec2-user', roles: %w[app db web]
 
+set :ssh_options, {
+  keys: (ENV['PRODUCTION_SSH_KEY']),
+  forward_agent: true
+}
+
 # role-based syntax
 # ==================
 

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -9,7 +9,7 @@
 server '35.79.33.31', user: 'ec2-user', roles: %w[app db web]
 
 set :ssh_options, {
-  keys: (ENV['PRODUCTION_SSH_KEY']),
+  keys: ENV.fetch('PRODUCTION_SSH_KEY', nil),
   forward_agent: true
 }
 


### PR DESCRIPTION
close #109 

**実装内容**
・CircleCIにSSH秘密鍵を登録し、config/deploy/production.rbに環境変数を設定しました。
・デプロイ先をHerokuからAWSに変更しました。
・SSH接続できることを確認し、GithubへpushしたときにCapistranoデプロイが走るように設定しました。
