### PR TITLE
レスポンシブの調整

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -80,7 +80,7 @@ footer {
   background-color: $anomaly-list-color;
   border-top: 1px solid $anomaly-list-border-color;
   border-bottom: 1px solid $anomaly-list-border-color;
-  margin: 0 250px 0px 250px;
+  margin: 0px 250px 0px 250px;
   padding: 30px 16px 0px 30px;
   width: 100%;
   box-shadow: 2px 2px 7px 6px RGB(0 0 0 / 4%);
@@ -88,6 +88,12 @@ footer {
   .reaction {
     display: flex;
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 767px) {
+  .m-mobile {
+    margin: 0 !important;
   }
 }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -51,10 +51,6 @@ a {
   }
 }
 
- /* body */
-body {
-}
-
 /* header */
 header {
   background-color: $main-color;

--- a/app/views/anomalys/_anomaly_list.html.erb
+++ b/app/views/anomalys/_anomaly_list.html.erb
@@ -1,7 +1,7 @@
 <% @anomalys.each do |anomaly| %>  
   <div class="col-xs-12 anomalys">
     <div class="row">
-      <div class="anomaly text-break">
+      <div class="anomaly text-break m-mobile">
         <div class="anomaly-header">
         <i class="bi bi-person"></i>
           <%= link_to "#{anomaly.user.name}", users_path(anomaly.user.id), class:"erb-link" %>

--- a/app/views/anomalys/index.html.erb
+++ b/app/views/anomalys/index.html.erb
@@ -11,11 +11,11 @@
     </div>
   <% end %>
 
-  <div class="col-xs-12 search-form">
+  <div class="search-form">
     <%= search_form_for @q, url: anomalys_path do |f| %>
       <div class="input-group">
         <%= f.search_field :title_cont, class: "form-control search-form-control col-md-5 offset-md-3 ", placeholder: 'キーワードを入力'  %>
-          <span class="input-group-btn">
+          <span class="">
             <%= f.button type: :submit, class: "btn-search" do %>
               <i class="bi bi-search"></i>
             <% end %>


### PR DESCRIPTION
close #111 

**実装内容**
・画面を小さくしたときレイアウトが崩れた箇所の調整をしました。
・異常一覧ページでスマホの画面サイズにした時検索フォームが画面からはみ出たので、不要なcssを削除しました。
・レスポンシブ調整の為画面を小さくしたとき投稿リストのmarginを0にしました。