### PR TITLE
AWSにデプロイ時Net::SSH::AuthenticationFailedエラーの対応

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -9,7 +9,7 @@
 server '35.79.33.31', user: 'ec2-user', roles: %w[app db web]
 
 set :ssh_options, {
-  keys: ENV.fetch('PRODUCTION_SSH_KEY', nil),
+  keys: [ENV.fetch('PRODUCTION_SSH_KEY').to_s],
   forward_agent: true
 }
 


### PR DESCRIPTION
・Net::SSH::AuthenticationFailed: Authentication failed for userが出た為、config/deploy/production.rbのssh keysの記述を変更をしました。